### PR TITLE
Fix to use .hyper.js instead of .hyperterm.js.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,10 @@
 # [hyperterm](https://hyperterm.org/)-final-say [![npm version](https://img.shields.io/npm/v/hyperterm-final-say.svg?style=flat-square)](http://www.npmjs.com/package/hyperterm-final-say)
 
-Allows user-set overrides of any plugin or theme settings applied on top of the defaults `./.hyperterm.js`.
+Allows user-set overrides of any plugin or theme settings applied on top of the defaults `./.hyper.js`.
 
 ### Install
 
-1. Open HyperTerm's preferences with `Cmd+,` (or manually at `~/.hyperterm.js`) with your editor.
+1. Open HyperTerm's preferences with `Cmd+,` (or manually at `~/.hyper.js`) with your editor.
 2. Put `hyperterm-final-say` as **last one** of plugin list, like so:
 
   ```js

--- a/index.js
+++ b/index.js
@@ -20,6 +20,8 @@ module.exports.decorateConfig = config => {
   userConfig.css = [config.css || '', userConfig.css || ''].join('\\n');
   userConfig.termCSS = [config.termCSS || '', userConfig.termCSS || ''].join('\\n');
   userConfig.fontSize = userConfig.fontSize || 12;
+  userConfig.backgroundColor = config.backgroundColor;
+  userConfig.borderColor = config.borderColor;
 
   return deepAssign({}, config, userConfig);
 };

--- a/index.js
+++ b/index.js
@@ -1,21 +1,25 @@
-const deepAssign = require('deep-assign')
-const { resolve } = require('path')
-const { homedir } = require('os')
-const userConfigPath = resolve(homedir(), '.hyperterm.js')
+const deepAssign = require('deep-assign');
+const {
+  resolve
+} = require('path');
+const {
+  homedir
+} = require('os');
+const userConfigPath = resolve(homedir(), '.hyper.js');
 
 module.exports.decorateConfig = config => {
-  let userConfig = {}
+  let userConfig = {};
 
   try {
-    delete require.cache[userConfigPath]
-    userConfig = require(userConfigPath).config
+    delete require.cache[userConfigPath];
+    userConfig = require(userConfigPath).config;
   } catch (e) {
-    console.error('ERR:', e)
+    console.error('ERR:', e);
   }
 
-  userConfig.css = [config.css || '', userConfig.css || ''].join('\\n')
-  userConfig.termCSS = [config.termCSS || '', userConfig.termCSS || ''].join('\\n')
-  userConfig.fontSize = userConfig.fontSize || 12
+  userConfig.css = [config.css || '', userConfig.css || ''].join('\\n');
+  userConfig.termCSS = [config.termCSS || '', userConfig.termCSS || ''].join('\\n');
+  userConfig.fontSize = userConfig.fontSize || 12;
 
-  return deepAssign({}, config, userConfig)
-}
+  return deepAssign({}, config, userConfig);
+};

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "hyperterm-final-say",
   "version": "1.1.0",
-  "description": "Allows user-set overrides of any plugin or theme settings applied on top of the defaults `./.hyperterm.js`.",
+  "description": "Allows user-set overrides of any plugin or theme settings applied on top of the defaults `./.hyper.js`.",
   "main": "index.js",
   "keywords": [
     "hyperterm",


### PR DESCRIPTION
I've updated all references to `.hyperterm.js` to now reference `.hyper.js`, which fixes the plugin with newer versions of Hyper. 